### PR TITLE
Fixed typo on "about" page

### DIFF
--- a/ui/src/app/pages/about/about.component.html
+++ b/ui/src/app/pages/about/about.component.html
@@ -42,7 +42,7 @@
       <h4>Development</h4>
     </div>
     <div>
-      KAG Stats is an opensoure piece of software that anybody is free to use and modify for their own purpose.
+      KAG Stats is an opensource piece of software that anybody is free to use and modify for their own purpose.
       The repository is hosted on <a href="https://github.com/Harrison-Miller/kagstats">github</a>. Anybody may fork the repository and
       submit PRs to improve the quality of the software. If you want to contribute but don't know where to start, see the
       <a href="https://trello.com/b/WR8dcqD7/kag-stats">trello board</a> listing tasks.


### PR DESCRIPTION
I know its extremely minor, but it bothered me for a long time