### PR TITLE
Fix events table not created on startup

### DIFF
--- a/collector/database/database.go
+++ b/collector/database/database.go
@@ -144,6 +144,13 @@ func (d *SQLDatabase) InitDB() error {
 		return errors.Wrap(err, "error creating kills table")
 	}
 
+	_, err = d.db.Exec(`CREATE TABLE IF NOT EXISTS events (
+		ID INTEGER PRIMARY KEY AUTO_INCREMENT
+	)`)
+	if err != nil {
+		return errors.Wrap(err, "error creating events table")
+	}
+
 	_, err = d.db.Exec(`CREATE TABLE IF NOT EXISTS stats_info (
 		key_name VARCHAR(30) PRIMARY KEY,
 		value INT NOT NULL	
@@ -265,7 +272,6 @@ func (d *SQLDatabase) CommitPlayer(player *models.Player) error {
 		return errors.Wrap(err, "error starting transaction")
 	}
 	defer tx.Rollback()
-
 
 	_, err = tx.Exec("UPDATE players SET oldgold=?,registered=?,role=?,avatar=?,tier=? WHERE ID=?",
 		player.OldGold, player.Registered, player.Role, player.Avatar, player.Tier, player.ID)

--- a/collector/database/migrations.go
+++ b/collector/database/migrations.go
@@ -501,17 +501,17 @@ func AddMapVotes(db *sqlx.DB) error {
 }
 
 func RemoveEvents(db *sqlx.DB) error {
-	err := DelFK("players", "players_ibfk_1", db)
-	if err != nil {
-		return err
-	}
+	// err := DelFK("players", "players_ibfk_1", db)
+	// if err != nil {
+	// 	return err
+	// }
 
-	err = DelColumn("players", "lastEventID", db)
-	if err != nil {
-		return err
-	}
+	// err = DelColumn("players", "lastEventID", db)
+	// if err != nil {
+	// 	return err
+	// }
 
-	_, err = db.Exec("DROP TABLE IF EXISTS events")
+	_, err := db.Exec("DROP TABLE IF EXISTS events")
 	if err != nil {
 		return err
 	}
@@ -521,15 +521,16 @@ func RemoveEvents(db *sqlx.DB) error {
 
 func RefreshPlayerInfo(db *sqlx.DB) error {
 	/*
-	players := []*models.Player{}
-	err := db.Select(&players, "SELECT * FROM players")
-	if err != nil {
-		return err
-	}
+	  players := []*models.Player{}
+	  err := db.Select(&players, "SELECT * FROM players")
+	  if err != nil {
+	    return err
+	  }
 
-	for _, player := range players {
-		updater.incoming <- *player
-	}*/
+	  for _, player := range players {
+	    updater.incoming <- *player
+	  }
+	*/
 	return nil
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,8 @@ services:
       args:
         VERSION: ${TAG:-latest}
     image: gcr.io/kagstats/api:${TAG:-latest}
+    ports:
+      - "8080:8080"
     environment:
       - KD_GATE=25
       - ARCHER_GATE=15

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,8 +35,6 @@ services:
       args:
         VERSION: ${TAG:-latest}
     image: gcr.io/kagstats/api:${TAG:-latest}
-    ports:
-      - "8080:8080"
     environment:
       - KD_GATE=25
       - ARCHER_GATE=15


### PR DESCRIPTION
The `events` table was not being created in `InitDB` meaning that the migrations would fail on startup since they were trying to use it.
I can see that this table is eventually dropped by a migration so it seems like a legacy thing which doesn't need to be in the DB anymore? I imagine it used to exist in `InitDB` and was removed at some point.

With this fix, `docker compose up` now correctly brings up the database schema